### PR TITLE
feat(run): kill existing emulator before run

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,13 @@ When loaded, the plugin looks for a [`pdxinfo`](https://sdk.play.date/2.6.2/Insi
 }
 ```
 
+## FAQ
+
+### Why is the Playdate Simulator display crash message when recompiling?
+
+You may need to disable the crash report prompt in your Playdate Simulator settings (Settings > General > Privacy > Send Crash Reports).
+
 ## See also
 
-- https://stephanmax.com/playdate-development-neovim/
-- https://devforum.play.date/t/neovim-central-thread/7953
+- <https://stephanmax.com/playdate-development-neovim/>
+- <https://devforum.play.date/t/neovim-central-thread/7953>

--- a/lua/playdate/compile.lua
+++ b/lua/playdate/compile.lua
@@ -95,6 +95,12 @@ function M._run(out)
 		return
 	end
 
+  -- If Simulator is already running, close it
+  local pid = vim.fn.system("pgrep -f 'Playdate Simulator'")
+  if pid ~= "" then
+    vim.fn.system("kill -TERM" .. pid)
+  end
+
 	vim.system({ playdate_simulator, out }, {
 		text = true,
 		stdout = false,

--- a/lua/playdate/compile.lua
+++ b/lua/playdate/compile.lua
@@ -3,6 +3,7 @@ local Util = require "playdate.util"
 
 local M = {
 	term = { buf = nil, win = nil, chan = nil },
+	playdate_simulator_pid = nil
 }
 
 function M.open_console()
@@ -95,13 +96,13 @@ function M._run(out)
 		return
 	end
 
-  -- If Simulator is already running, close it
-  local pid = vim.fn.system("pgrep -f 'Playdate Simulator'")
-  if pid ~= "" then
-    vim.fn.system("kill -TERM" .. pid)
-  end
+	-- If Simulator is already running, close it
+	if M.playdate_simulator_pid ~= nil then
+		vim.system({ "kill", "-QUIT", tostring(M.playdate_simulator_pid) }):wait()
+		M.playdate_simulator_pid = nil
+	end
 
-	vim.system({ playdate_simulator, out }, {
+	M.playdate_simulator_pid = vim.system({ playdate_simulator, out }, {
 		text = true,
 		stdout = false,
 		stderr = false,
@@ -109,7 +110,7 @@ function M._run(out)
 		if out.code ~= 0 then
 			Util.notify("Playdate Simulator exited with error code: " .. out.code, vim.log.levels.ERROR)
 		end
-	end)
+	end).pid
 end
 
 ---@param src string?


### PR DESCRIPTION
Hey, first of all, thanks for this nice nvim plugin, very helpful to develop faster using nvim !

## Description

Here is a small PR to avoid multiplying the number of `Playdate Simulator` running (occuring on at least MacOS).
This prevents opening every time a new instance of the simulator when running a compiled pdx file.